### PR TITLE
initdb configmap name

### DIFF
--- a/galaxy/templates/configmap-initdb.yaml
+++ b/galaxy/templates/configmap-initdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $fullName }}-initdb
+  name: galaxy-initdb
   labels:
     app: {{ template "galaxy.name" . }}
     chart: {{ template "galaxy.chart" . }}


### PR DESCRIPTION
The name is mismatched between the creation and referencing. It seemed easiest to just hard-code the name to avoid having to run values through `tpl`, but not entirely sure if there is something that makes this undesirable, so leaving it as a PR until something is decided.