### PR TITLE
Configmap name same as defined in .Values.postgresql.initdbScriptsConfigMap

### DIFF
--- a/galaxy/templates/configmap-initdb.yaml
+++ b/galaxy/templates/configmap-initdb.yaml
@@ -1,8 +1,7 @@
-{{- $fullName := include "galaxy.fullname" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $fullName }}-initdb
+  name: {{ .Release.Name }}-galaxy-initdb
   labels:
     app: {{ template "galaxy.name" . }}
     chart: {{ template "galaxy.chart" . }}


### PR DESCRIPTION
Explicitly naming the configmap the same way as it's being called in `values.yaml`: https://github.com/CloudVE/galaxy-kubernetes/blob/v3/galaxy/values.yaml#L123