### PR TITLE
Enable Galaxy Kubernetes Runner

### DIFF
--- a/galaxy/templates/configmap-galaxy-conf.yaml
+++ b/galaxy/templates/configmap-galaxy-conf.yaml
@@ -11,6 +11,6 @@ data:
   {{- range $key, $entry := .Values.configs -}}
   {{- if $entry -}}
   {{- $key | nindent 2 }}: |
-    {{- tpl ($entry | toYaml | replace "{{\n" "{{" | replace "\n    }}" " }}" | replace "|" "") $ | nindent 4 -}}
+    {{- tpl ($entry | toYaml | replace "{{\n" "{{" | replace "\n    }}" " }}" | replace "|" "") $ | indent 4 -}}
     {{- end }}
   {{- end }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "galaxy.fullname" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/galaxy_conf: {{ include (print $.Template.BasePath "/configmap-galaxy-conf.yaml") . | sha256sum }}
     spec:
       securityContext:
         fsGroup: 101

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -27,7 +27,7 @@ spec:
           command: ['sh', '-c', 'until nc -z -w3 {{ template "galaxy-postgresql.fullname" $ }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done;']
         - name: {{ .Chart.Name }}-init-mounts
           image: alpine:3.7
-          command: ['sh', '-c', 'chown -R 101:101 /galaxy/server/database && cp /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/editable/integrated_tool_panel.xml']
+          command: ['sh', '-c', 'chown -R 101:101 /galaxy/server/database && install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/editable/integrated_tool_panel.xml']
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -30,7 +30,7 @@ spec:
           command: ['sh', '-c', 'until nc -z -w3 {{ template "galaxy-postgresql.fullname" $ }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done;']
         - name: {{ .Chart.Name }}-init-mounts
           image: alpine:3.7
-          command: ['sh', '-c', 'chown -R 101:101 /galaxy/server/database && cp /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/editable/integrated_tool_panel.xml']
+          command: ['sh', '-c', 'chown -R 101:101 /galaxy/server/database && install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/editable/integrated_tool_panel.xml']
           volumeMounts:
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files

--- a/galaxy/templates/rbac-job.yaml
+++ b/galaxy/templates/rbac-job.yaml
@@ -1,0 +1,37 @@
+{{ if .Values.rbac.enabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "galaxy.fullname" . }}-role-pod-jobs
+  labels:
+    app.kubernetes.io/name: {{ include "galaxy.name" . }}
+    helm.sh/chart: {{ include "galaxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "galaxy.fullname" . }}-batch-ops
+  labels:
+    app.kubernetes.io/name: {{ include "galaxy.name" . }}
+    helm.sh/chart: {{ include "galaxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "galaxy.fullname" . }}-role-pod-jobs
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -86,12 +86,26 @@ configs:
   job_conf.xml: |
       <job_conf>
           <plugins>
-              <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
+              <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4" />
+              <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
+                <param id="k8s_use_service_account">true</param>
+                <param id="k8s_persistent_volume_claims">
+                  {{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database/files,
+                  {{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database/job_working_directory
+                </param>
+              </plugin>
           </plugins>
           <handlers assign_with="db-skip-locked" />
-          <destinations>
+          <destinations default="local_k8s">
               <destination id="local" runner="local"/>
+              <destination id="local_k8s" runner="k8s">
+                <param id="docker_enabled">true</param>
+              </destination>
           </destinations>
+          <tools>
+            <!-- Should not be needed in the long run. -->
+            <tool id="upload1" destination="local" />
+          </tools>
       </job_conf>
   galaxy.yml: |
       uwsgi:
@@ -115,6 +129,7 @@ configs:
         py-call-osafterfork: true
       galaxy:
         database_connection: 'postgresql://{{.Values.postgresql.username}}:{{.Values.postgresql.password}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
+        cleanup_job: onsuccess
         integrated_tool_panel_config: "/galaxy/server/config/editable/integrated_tool_panel.xml"
         tool_config_file: "{{ .Values.cvmfs.main.mountPath }}/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
         tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml"

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -20,6 +20,9 @@ webHandlers:
 jobHandlers:
   replicaCount: 1
 
+rbac:
+  enabled: true
+
 persistence:
   enabled: true
   name: &pvcname galaxy-pvc
@@ -89,17 +92,25 @@ configs:
               <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4" />
               <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
                 <param id="k8s_use_service_account">true</param>
-                <param id="k8s_persistent_volume_claims">
-                  {{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database/files,
-                  {{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database/job_working_directory
-                </param>
+                <param id="k8s_persistent_volume_claims">{{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database</param>
+                <param id="k8s_namespace">{{ .Release.Namespace }}</param>
+                <!-- Must be DNS friendly and less than 20 characters -->
+                <param id="k8s_galaxy_instance_id">{{ .Release.Namespace }}</param>
+                <param id="k8s_supplemental_group_id">101</param>
+                <param id="k8s_pull_policy">IfNotPresent</param>
               </plugin>
           </plugins>
           <handlers assign_with="db-skip-locked" />
           <destinations default="local_k8s">
               <destination id="local" runner="local"/>
               <destination id="local_k8s" runner="k8s">
+                <param id="enabled">true</param>
                 <param id="docker_enabled">true</param>
+                <param id="docker_sudo">False</param>
+                <!-- For a stock Galaxy instance and traditional job runner $defaults will expand out
+                     as: $galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:rw -->
+                <param id="docker_volumes">$defaults</param>
+                <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
               </destination>
           </destinations>
           <tools>
@@ -135,6 +146,12 @@ configs:
         tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml"
         tool_dependency_dir: "{{ .Values.cvmfs.main.mountPath }}/deps"
         builds_file_path: "{{.Values.cvmfs.data.mountPath}}/managed/location/builds.txt"
+        containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
+  container_resolvers_conf.xml: |
+      <containers_resolvers>
+        <explicit />
+        <mulled />
+      </containers_resolvers>
   # This is the last entry in the file given its length
   integrated_tool_panel.xml: |
       <?xml version="1.0"?>

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -101,6 +101,7 @@ configs:
                 <param id="k8s_fs_group_id">101</param>
                 <param id="k8s_supplemental_group_id">101</param>
                 <param id="k8s_pull_policy">IfNotPresent</param>
+                <param id="k8s_cleanup_job">always</param>
               </plugin>
           </plugins>
           <handlers assign_with="db-skip-locked" />

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -92,7 +92,7 @@ configs:
               <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4" />
               <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
                 <param id="k8s_use_service_account">true</param>
-                <param id="k8s_persistent_volume_claims">{{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database</param>
+                <param id="k8s_persistent_volume_claims">{{ .Release.Name }}-{{ .Values.persistence.name }}:/galaxy/server/database,{{ template "galaxy.fullname" . }}-cvmfs-gxy-data-pvc:{{ .Values.cvmfs.data.mountPath }}</param>
                 <param id="k8s_namespace">{{ .Release.Namespace }}</param>
                 <!-- Must be DNS friendly and less than 20 characters -->
                 <param id="k8s_galaxy_instance_id">{{ .Release.Namespace }}</param>
@@ -110,9 +110,6 @@ configs:
                 <param id="enabled">true</param>
                 <param id="docker_enabled">true</param>
                 <param id="docker_sudo">False</param>
-                <!-- For a stock Galaxy instance and traditional job runner $defaults will expand out
-                     as: $galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:rw -->
-                <param id="docker_volumes">$defaults</param>
                 <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
               </destination>
           </destinations>

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -96,6 +96,9 @@ configs:
                 <param id="k8s_namespace">{{ .Release.Namespace }}</param>
                 <!-- Must be DNS friendly and less than 20 characters -->
                 <param id="k8s_galaxy_instance_id">{{ .Release.Namespace }}</param>
+                <param id="k8s_run_as_user_id">101</param>
+                <param id="k8s_run_as_group_id">101</param>
+                <param id="k8s_fs_group_id">101</param>
                 <param id="k8s_supplemental_group_id">101</param>
                 <param id="k8s_pull_policy">IfNotPresent</param>
               </plugin>
@@ -140,7 +143,6 @@ configs:
         py-call-osafterfork: true
       galaxy:
         database_connection: 'postgresql://{{.Values.postgresql.username}}:{{.Values.postgresql.password}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
-        cleanup_job: onsuccess
         integrated_tool_panel_config: "/galaxy/server/config/editable/integrated_tool_panel.xml"
         tool_config_file: "{{ .Values.cvmfs.main.mountPath }}/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
         tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml"


### PR DESCRIPTION
Containers for jobs/tools need to be found somewhere, somehow:
```
galaxy.jobs.mapper DEBUG 2019-05-31 16:01:27,709 (4) Mapped job to destination id: local_k8s
galaxy.jobs.handler DEBUG 2019-05-31 16:01:27,724 (4) Dispatching to k8s runner
galaxy.jobs DEBUG 2019-05-31 16:01:27,744 (4) Persisting job destination (destination id: local_k8s)
galaxy.jobs DEBUG 2019-05-31 16:01:27,752 (4) Working directory for job is: /galaxy/server/database/jobs_directory/000/4
galaxy.jobs.runners DEBUG 2019-05-31 16:01:27,779 Job [4] queued (54.815 ms)
galaxy.jobs.handler INFO 2019-05-31 16:01:27,808 (4) Job dispatched
galaxy.jobs.runners.kubernetes DEBUG 2019-05-31 16:01:27,842 Starting queue_job for job 4
galaxy.tools.deps.containers INFO 2019-05-31 16:01:28,222 Checking with container resolver [ExplicitContainerResolver[]] found description [None]
galaxy.jobs.command_factory INFO 2019-05-31 16:01:28,250 Built script [/galaxy/server/database/jobs_directory/000/4/tool_script.sh] for tool command [perl '/galaxy/server/tools/filters/headWrapper.pl' '/galaxy/server/database/files/000/dataset_3.dat' 1 '/galaxy/server/database/files/000/dataset_4.dat']
galaxy.jobs.runners DEBUG 2019-05-31 16:01:28,299 (4) command is: out="${TMPDIR:-/tmp}/out.$$" err="${TMPDIR:-/tmp}/err.$$"
mkfifo "$out" "$err"
trap 'rm "$out" "$err"' EXIT
tee -a stdout.log < "$out" &
tee -a stderr.log < "$err" >&2 & rm -rf working; mkdir -p working; cd working; /galaxy/server/database/jobs_directory/000/4/tool_script.sh > ../tool_stdout 2> ../tool_stderr > '/galaxy/server/database/jobs_directory/000/4/galaxy_4.o' 2> '/galaxy/server/database/jobs_directory/000/4/galaxy_4.e'; return_code=$?; sh -c "exit $return_code"
galaxy.tools.deps.containers INFO 2019-05-31 16:01:28,329 Checking with container resolver [ExplicitContainerResolver[]] found description [None]
galaxy.jobs.runners ERROR 2019-05-31 16:01:28,329 (4) Unhandled exception calling queue_job
Traceback (most recent call last):
  File "/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 130, in run_next
    method(arg)
  File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 130, in queue_job
    "spec": self.__get_k8s_job_spec(ajs)
  File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 221, in __get_k8s_job_spec
    k8s_job_spec = {"template": self.__get_k8s_job_spec_template(ajs)}
  File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 235, in __get_k8s_job_spec_template
    "containers": self.__get_k8s_containers(ajs)
  File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 265, in __get_k8s_containers
    "image": self._find_container(ajs.job_wrapper).container_id,
AttributeError: 'NullContainer' object has no attribute 'container_id'
```

xref #16