### PR TITLE
Handle galaxy db password as a secret

### DIFF
--- a/galaxy/files/conf.d/init1_dbobjects.sh
+++ b/galaxy/files/conf.d/init1_dbobjects.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRESQL_USERNAME" --dbname "$POSTGRESQL_DATABASE" <<-EOSQL
+psql -v ON_ERROR_STOP=1 -v GXYPASSWORD="'$GALAXY_DB_USER_PASSWORD'" --username "$POSTGRESQL_USERNAME" --dbname "$POSTGRESQL_DATABASE" <<-EOSQL
 		CREATE DATABASE galaxy;
 		CREATE USER {{.Values.postgresql.galaxyDatabaseUser}};
-		ALTER ROLE {{.Values.postgresql.galaxyDatabaseUser}} WITH PASSWORD '{{.Values.postgresql.galaxyDatabasePassword}}';
+		ALTER ROLE {{.Values.postgresql.galaxyDatabaseUser}} WITH PASSWORD :GXYPASSWORD;
 		GRANT ALL PRIVILEGES ON DATABASE galaxy TO {{.Values.postgresql.galaxyDatabaseUser}};
 		ALTER DATABASE galaxy OWNER TO {{.Values.postgresql.galaxyDatabaseUser}};
 EOSQL

--- a/galaxy/requirements.lock
+++ b/galaxy/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.4
-digest: sha256:3ce8113968f2c022dcda3a627939a763f4707feb5a1fa44e151a2ec6c9987bd7
-generated: 2019-06-10T18:08:20.363908+05:30
+  version: 5.3.6
+digest: sha256:7f403b86e39331034ad7cb53cfecc4d13742300b1f279efb9c6776de5beab520
+generated: 2019-06-11T17:55:46.551043+05:30

--- a/galaxy/requirements.lock
+++ b/galaxy/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.2.0
-digest: sha256:c302cf4a24c05b4d7dcf6088e3ce0f1c78453ee4c84e39b3aeafcddc39eee30a
-generated: 2019-05-15T09:19:03.415701-04:00
+  version: 5.3.4
+digest: sha256:3ce8113968f2c022dcda3a627939a763f4707feb5a1fa44e151a2ec6c9987bd7
+generated: 2019-06-10T18:08:20.363908+05:30

--- a/galaxy/requirements.yaml
+++ b/galaxy/requirements.yaml
@@ -8,5 +8,5 @@
 dependencies:
     - name: postgresql
       repository: https://kubernetes-charts.storage.googleapis.com/
-      version: 5.3.4
+      version: 5.3.6
       condition: postgresql.enabled

--- a/galaxy/requirements.yaml
+++ b/galaxy/requirements.yaml
@@ -8,5 +8,5 @@
 dependencies:
     - name: postgresql
       repository: https://kubernetes-charts.storage.googleapis.com/
-      version: 4.2.0
+      version: 5.3.4
       condition: postgresql.enabled

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -49,3 +49,21 @@ Add a trailing slash to a given path, if missing
 {{- printf "%s/" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return galaxy database user password
+*/}}
+{{- define "galaxy.galaxyDbPassword" -}}
+{{- if .Values.postgresql.galaxyDatabasePassword }}
+    {{- .Values.postgresql.galaxyDatabasePassword -}}
+{{- else -}}
+    {{- randAlphaNum 10 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return galaxy database connection string
+*/}}
+{{- define "galaxy.galaxyDbConnectionString" -}}
+postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
+{{- end -}}

--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -51,6 +51,23 @@ Add a trailing slash to a given path, if missing
 {{- end -}}
 
 {{/*
+Decide whether to create a new secret or use an existing secret.
+It creates a new secret if the value is the expected default, and assumes it's an
+existing secret in all other cases.
+*/}}
+{{- define "galaxy.createGalaxyDbSecret" -}}
+{{- range $key, $entry := .Values.extraEnv -}}
+{{- if eq $entry.name "GALAXY_DB_USER_PASSWORD" -}}
+    {{- if eq $entry.valueFrom.secretKeyRef.name "{{ .Release.Name }}-galaxy-db-password" -}}
+        {{- true -}}
+    {{- else -}}
+    {{- end -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return galaxy database user password
 */}}
 {{- define "galaxy.galaxyDbPassword" -}}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -49,6 +49,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+{{- if .Values.extraEnv }}
+{{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
+{{- end }}
           command: ["python", "/galaxy/server/scripts/galaxy-main"]
           args: ["-c", "/galaxy/server/config/galaxy.yml", "--server-name", "$(POD_NAME)", "--attach-to-pool", "job-handlers"]
           volumeMounts:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -53,6 +53,10 @@ spec:
             - name: galaxy-http
               containerPort: 8080
               protocol: TCP
+          env:
+{{- if .Values.extraEnv }}
+{{ tpl (toYaml .Values.extraEnv) . | indent 12 }}
+{{- end }}
           command: ["/galaxy/server/.venv/bin/uwsgi"]
           args: ["--yaml", "/galaxy/server/config/galaxy.yml"]
           volumeMounts:

--- a/galaxy/templates/secret-galaxydb.yaml
+++ b/galaxy/templates/secret-galaxydb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Release.Name }}-galaxy-db-password
+  labels:
+    app.kubernetes.io/name: {{ include "galaxy.name" . }}
+    helm.sh/chart: {{ include "galaxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  galaxy-db-password: {{ include "galaxy.galaxyDbPassword" . | b64enc | quote }}

--- a/galaxy/templates/secret-galaxydb.yaml
+++ b/galaxy/templates/secret-galaxydb.yaml
@@ -1,3 +1,4 @@
+{{- if (include "galaxy.createGalaxyDbSecret" .) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -10,3 +11,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   galaxy-db-password: {{ include "galaxy.galaxyDbPassword" . | b64enc | quote }}
+{{- end }}

--- a/galaxy/values-minimal.yaml
+++ b/galaxy/values-minimal.yaml
@@ -31,6 +31,15 @@ persistence:
   accessMode: ReadWriteMany
   size: 10Gi
 
+extraEnv:
+  - name: GALAXY_DB_USER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "{{ .Release.Name }}-galaxy-db-password"
+        key: galaxy-db-password
+  - name: GALAXY_CONFIG_DATABASE_CONNECTION
+    value: '{{ include "galaxy.galaxyDbConnectionString" $ }}'
+
 ingress:
   enabled: true
   annotations: {}
@@ -67,7 +76,7 @@ affinity: {}
 postgresql:
   enabled: true
   galaxyDatabaseUser: galaxydbuser
-  galaxyDatabasePassword: 42
+  galaxyDatabasePassword:
   nameOverride: galaxy-postgres
   initdbScriptsSecret: "{{ .Release.Name }}-galaxy-initdb"
   persistence:
@@ -130,7 +139,6 @@ configs:
       enable-threads: true
       py-call-osafterfork: true
     galaxy:
-      database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
   container_resolvers_conf.xml: |
     <containers_resolvers>

--- a/galaxy/values-minimal.yaml
+++ b/galaxy/values-minimal.yaml
@@ -32,6 +32,8 @@ persistence:
   size: 10Gi
 
 extraEnv:
+# If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's
+# secretKeyRef must also be set to match. Leave defaults to create a new secret.
   - name: GALAXY_DB_USER_PASSWORD
     valueFrom:
       secretKeyRef:
@@ -81,6 +83,12 @@ postgresql:
   initdbScriptsSecret: "{{ .Release.Name }}-galaxy-initdb"
   persistence:
     enabled: true
+  extraEnv:
+    - name: GALAXY_DB_USER_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: "{{ .Release.Name }}-galaxy-db-password"
+          key: galaxy-db-password
 
 cvmfs:
   enabled: false

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -32,6 +32,8 @@ persistence:
   size: 10Gi
 
 extraEnv:
+# If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's
+# secretKeyRef must also be set to match. Leave defaults to create a new secret.
   - name: GALAXY_DB_USER_PASSWORD
     valueFrom:
       secretKeyRef:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -31,6 +31,13 @@ persistence:
   accessMode: ReadWriteMany
   size: 10Gi
 
+extraEnv: []
+#  - name: GALAXY_CONFIG_MY_EXTRA_VAR
+#    valueFrom:
+#      secretKeyRef:
+#        name: "{{.Release.Name}}-my-secret"
+#        key: galaxy-db-password
+
 ingress:
   enabled: true
   annotations: {}

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -11,7 +11,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: NodePort
+  type: ClusterIP
   port: 8090
 
 webHandlers:
@@ -31,12 +31,14 @@ persistence:
   accessMode: ReadWriteMany
   size: 10Gi
 
-extraEnv: []
-#  - name: GALAXY_CONFIG_MY_EXTRA_VAR
-#    valueFrom:
-#      secretKeyRef:
-#        name: "{{.Release.Name}}-my-secret"
-#        key: galaxy-db-password
+extraEnv:
+  - name: GALAXY_DB_USER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "{{ .Release.Name }}-galaxy-db-password"
+        key: galaxy-db-password
+  - name: GALAXY_CONFIG_DATABASE_CONNECTION
+    value: '{{ include "galaxy.galaxyDbConnectionString" $ }}'
 
 ingress:
   enabled: true
@@ -74,11 +76,17 @@ affinity: {}
 postgresql:
   enabled: true
   galaxyDatabaseUser: galaxydbuser
-  galaxyDatabasePassword: 42
+  galaxyDatabasePassword:
   nameOverride: galaxy-postgres
   initdbScriptsSecret: "{{ .Release.Name }}-galaxy-initdb"
   persistence:
     enabled: true
+  extraEnv:
+    - name: GALAXY_DB_USER_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: "{{ .Release.Name }}-galaxy-db-password"
+          key: galaxy-db-password
 
 cvmfs:
   enabled: true
@@ -147,7 +155,6 @@ configs:
       enable-threads: true
       py-call-osafterfork: true
     galaxy:
-      database_connection: 'postgresql://{{.Values.postgresql.galaxyDatabaseUser}}:{{.Values.postgresql.galaxyDatabasePassword}}@{{ template "galaxy-postgresql.fullname" . }}/galaxy'
       integrated_tool_panel_config: "/galaxy/server/config/editable/integrated_tool_panel.xml"
       tool_config_file: "{{ .Values.cvmfs.main.mountPath }}/config/tool_conf.xml,{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_conf.xml"
       tool_data_table_config_path: "{{ .Values.cvmfs.main.mountPath }}/config/shed_tool_data_table_conf.xml,{{.Values.cvmfs.data.mountPath}}/managed/location/tool_data_table_conf.xml"


### PR DESCRIPTION
Closes: https://github.com/CloudVE/galaxy-kubernetes/issues/28
This requires a change in the postgresql chart so that it allows templating of extraEnvs.
Pending PR: https://github.com/helm/charts/pull/14664

The only way I could get this to work correctly as a secret was by passing the database connection string as an env var named  GALAXY_CONFIG_DATABASE_CONNECTION instead of using galaxy.yml