### PR TITLE
Custom init containers and init scripts

### DIFF
--- a/galaxy/templates/_helpers.tpl
+++ b/galaxy/templates/_helpers.tpl
@@ -93,5 +93,5 @@ Return galaxy database user password
 Creates the bash command for the init containers used to place files and change permissions in the galaxy pods
 */}}
 {{- define "galaxy.init-container-commands" -}}
-{{- tpl "install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt; if [ ! -f \"{{.Values.persistence.mountPath}}/config/editable_shed_tool_conf.xml\" ]; then install -D -o 101 -g 101 /galaxy/server/config/shed_tool_conf.xml.sample {{.Values.persistence.mountPath}}/config/editable_shed_tool_conf.xml; fi" $}}
+{{- tpl "install -o 101 -g 101 /galaxy/server/config/integrated_tool_panel.xml /galaxy/server/config/mutable/integrated_tool_panel.xml; install -o 101 -g 101 /galaxy/server/config/sanitize_whitelist.txt /galaxy/server/config/mutable/sanitize_whitelist.txt; if [ ! -f \"{{ .Values.persistence.mountPath }}/config/editable_shed_tool_conf.xml\" ]; then install -D -o 101 -g 101 /galaxy/server/config/shed_tool_conf.xml.sample {{ .Values.persistence.mountPath }}/config/editable_shed_tool_conf.xml; fi" $}}
 {{- end -}}

--- a/galaxy/templates/configmap-scripts.yaml
+++ b/galaxy/templates/configmap-scripts.yaml
@@ -1,14 +1,13 @@
-{{- $dot := . -}}
 {{- range $key, $entry := .Values.initScripts -}}
 {{- if $entry }}
 apiVersion: v1
 metadata:
-  name: {{ include "galaxy.fullname" $dot }}-{{$key}}
+  name: {{ include "galaxy.fullname" $ }}-{{$key}}
   labels:
-    app.kubernetes.io/name: {{ include "galaxy.name" $dot }}
-    helm.sh/chart: {{ include "galaxy.chart" $dot }}
-    app.kubernetes.io/instance: {{ $dot.Release.Name }}
-    app.kubernetes.io/managed-by: {{ $dot.Release.Service }}
+    app.kubernetes.io/name: {{ include "galaxy.name" $ }}
+    helm.sh/chart: {{ include "galaxy.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
 {{- if $entry.useSecret }}
 kind: Secret
 type: Opaque
@@ -22,4 +21,3 @@ data: |
 ---
 {{- end }}
 {{- end }}
-

--- a/galaxy/templates/configmap-scripts.yaml
+++ b/galaxy/templates/configmap-scripts.yaml
@@ -3,7 +3,7 @@
 {{- if $entry }}
 apiVersion: v1
 metadata:
-  name: {{ include "galaxy.fullname" $ }}-{{$key}}
+  name: {{ include "galaxy.fullname" $ }}-{{ $key }}
   labels:
     app.kubernetes.io/name: {{ include "galaxy.name" $ }}
     helm.sh/chart: {{ include "galaxy.chart" $ }}

--- a/galaxy/templates/configmap-scripts.yaml
+++ b/galaxy/templates/configmap-scripts.yaml
@@ -1,4 +1,5 @@
 {{- range $key, $entry := .Values.initScripts -}}
+{{- if (not (eq $key "mountPath")) -}}
 {{- if $entry }}
 apiVersion: v1
 metadata:
@@ -11,13 +12,14 @@ metadata:
 {{- if $entry.useSecret }}
 kind: Secret
 type: Opaque
-stringData: |
+stringData:
 {{- else }}
 kind: ConfigMap
-data: |
+data:
 {{- end }}
   {{- $key | nindent 2 }}.sh: |
     {{- tpl (tpl $entry.content $) $ | nindent 4 }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/galaxy/templates/configmap-scripts.yaml
+++ b/galaxy/templates/configmap-scripts.yaml
@@ -1,4 +1,4 @@
-{{- range $key, $entry := .Values.initScripts -}}
+{{- range $key, $entry := .Values.extraInitScripts -}}
 {{- if (not (eq $key "mountPath")) -}}
 {{- if $entry }}
 apiVersion: v1

--- a/galaxy/templates/configmap-scripts.yaml
+++ b/galaxy/templates/configmap-scripts.yaml
@@ -3,7 +3,7 @@
 {{- if $entry }}
 apiVersion: v1
 metadata:
-  name: {{ include "galaxy.fullname" $ }}-{{ $key }}
+  name: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}
   labels:
     app.kubernetes.io/name: {{ include "galaxy.name" $ }}
     helm.sh/chart: {{ include "galaxy.chart" $ }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -44,6 +44,34 @@ spec:
               subPath: config
             - name: galaxy-data
               mountPath: {{.Values.persistence.mountPath}}
+        - name: {{ .Chart.Name }}-initscripts
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ['sh', '-c', 'echo "Starting to run init scripts"
+          {{- range $key, $entry := .Values.initScripts -}}
+          {{- if $entry.applyToJob -}}
+           && echo "Running {{$key}}.sh" && sh /galaxy/initscripts/{{$key}}.sh
+          {{- end -}}
+          {{- end -}}
+          ']
+          volumeMounts:
+            {{- range $key, $entry := .Values.initScripts -}}
+            {{- if $entry.applyToJob }}
+            - name: galaxy-initscripts-{{$key}}
+              mountPath: /galaxy/initscripts
+              subPath: {{$key}}.sh
+            - name: galaxy-data
+              mountPath: {{ $.Values.persistence.mountPath }}
+            {{- end }}
+            {{- end }}
+        {{- range $key, $entry := .Values.initContainers -}}
+        {{- if $entry.applyToJob }}
+        - name: {{ $.Chart.Name}}-{{ $key }}
+          image: {{ tpl $entry.image $ }}
+          command: {{ tpl $entry.command $ }}
+          volumeMounts:
+            {{- tpl ($entry.volumeMounts | toYaml) $ | nindent 12 }}
+        {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-job
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -92,6 +120,18 @@ spec:
           {{- else }}
           configMap:
             name: {{ template "galaxy.fullname" . }}-configs
+          {{- end }}
+          {{- range $key, $entry := .Values.initScripts -}}
+          {{- if $entry.applyToJob }}
+        - name: galaxy-initscripts-{{$key}}
+          {{- if $entry.useSecret }}
+          secret:
+            secretName: {{ include "galaxy.fullname" $ }}-{{$key}}
+          {{- else }}
+          configMap:
+            name: {{ include "galaxy.fullname" $ }}-{{$key}}
+          {{- end }}
+          {{- end }}
           {{- end }}
         - name: galaxy-job-rules
           configMap:

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -67,21 +67,21 @@ spec:
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
           command: ['sh', '-c', '
-          {{- range $key, $entry := .Values.initScripts -}}
+          {{- range $key, $entry := .Values.extraInitScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToJob -}}
-          sh {{ $.Values.initScripts.mountPath }}/{{ $key }}{{ ".sh && " }}
+          sh {{ $.Values.extraInitScripts.mountPath }}/{{ $key }}{{ ".sh && " }}
           {{- end -}}
           {{- end -}}
           {{- end -}}
           python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name $(POD_NAME) --attach-to-pool job-handlers']
           args: []
           volumeMounts:
-            {{- range $key, $entry := .Values.initScripts -}}
+            {{- range $key, $entry := .Values.extraInitScripts -}}
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToJob }}
-            - name: galaxy-initscripts-{{ $key | lower }}
-              mountPath: {{ $.Values.initScripts.mountPath }}/{{ $key }}.sh
+            - name: galaxy-extraInitScripts-{{ $key | lower }}
+              mountPath: {{ $.Values.extraInitScripts.mountPath }}/{{ $key }}.sh
               subPath: {{ $key }}.sh
             {{- end }}
             {{- end }}
@@ -118,10 +118,10 @@ spec:
           configMap:
             name: {{ template "galaxy.fullname" . }}-configs
           {{- end }}
-          {{- range $key, $entry := .Values.initScripts -}}
+          {{- range $key, $entry := .Values.extraInitScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToJob }}
-        - name: galaxy-initscripts-{{ $key | lower }}
+        - name: galaxy-extraInitScripts-{{ $key | lower }}
           {{- if $entry.useSecret }}
           secret:
             secretName: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -44,25 +44,6 @@ spec:
               subPath: config
             - name: galaxy-data
               mountPath: {{.Values.persistence.mountPath}}
-        - name: {{ .Chart.Name }}-initscripts
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ['sh', '-c', 'echo "Starting to run init scripts"
-          {{- range $key, $entry := .Values.initScripts -}}
-          {{- if $entry.applyToJob -}}
-           && echo "Running {{$key}}.sh" && sh /galaxy/initscripts/{{$key}}.sh
-          {{- end -}}
-          {{- end -}}
-          ']
-          volumeMounts:
-            {{- range $key, $entry := .Values.initScripts -}}
-            {{- if $entry.applyToJob }}
-            - name: galaxy-initscripts-{{$key}}
-              mountPath: /galaxy/initscripts
-              subPath: {{$key}}.sh
-            - name: galaxy-data
-              mountPath: {{ $.Values.persistence.mountPath }}
-            {{- end }}
-            {{- end }}
         {{- range $key, $entry := .Values.initContainers -}}
         {{- if $entry.applyToJob }}
         - name: {{ $.Chart.Name}}-{{ $key }}
@@ -86,9 +67,26 @@ spec:
 {{- end }}
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
-          command: ["python", "/galaxy/server/scripts/galaxy-main"]
-          args: ["-c", "/galaxy/server/config/galaxy.yml", "--server-name", "$(POD_NAME)", "--attach-to-pool", "job-handlers"]
+          command: ['
+          {{- range $key, $entry := .Values.initScripts -}}
+          {{- if (not (eq $key "mountPath")) -}}
+          {{- if $entry.applyToJob -}}
+          sh {{ $.Values.initScripts.mountPath }}/{{ $key }}{{ ".sh && " }}
+          {{- end -}}
+          {{- end -}}
+          {{- end -}}
+          python', '/galaxy/server/scripts/galaxy-main']
+          args: ['-c', '/galaxy/server/config/galaxy.yml', '--server-name', '$(POD_NAME)', '--attach-to-pool', 'job-handlers']
           volumeMounts:
+            {{- range $key, $entry := .Values.initScripts -}}
+            {{- if (not (eq $key "mountPath")) -}}
+            {{- if $entry.applyToJob }}
+            - name: galaxy-initscripts-{{$key}}
+              mountPath: {{ $.Values.initScripts.mountPath }}
+              subPath: {{$key}}.sh
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files
               mountPath: /galaxy/server/config/{{ $key }}
@@ -122,6 +120,7 @@ spec:
             name: {{ template "galaxy.fullname" . }}-configs
           {{- end }}
           {{- range $key, $entry := .Values.initScripts -}}
+          {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToJob }}
         - name: galaxy-initscripts-{{$key}}
           {{- if $entry.useSecret }}
@@ -130,6 +129,7 @@ spec:
           {{- else }}
           configMap:
             name: {{ include "galaxy.fullname" $ }}-{{$key}}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -44,13 +44,12 @@ spec:
               subPath: config
             - name: galaxy-data
               mountPath: {{ .Values.persistence.mountPath }}
-        {{- range $key, $entry := .Values.initContainers -}}
-        {{- if $entry.applyToJob }}
-        - name: {{ $.Chart.Name}}-{{ $key }}
-          image: {{ tpl $entry.image $ }}
-          command: {{ tpl $entry.command $ }}
-          volumeMounts:
-            {{- tpl ($entry.volumeMounts | toYaml) $ | nindent 12 }}
+        {{- if .Values.extraInitContainers -}}
+        {{- range $each := .Values.extraInitContainers -}}
+        {{- if $each.applyToJob -}}
+        {{- print "- " | nindent 8 -}}
+        {{- tpl ((unset (unset $each "applyToJob") "applyToWeb") | toYaml | indent 10 | trim) $ -}}
+        {{- end }}
         {{- end }}
         {{- end }}
       containers:

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -80,7 +80,7 @@ spec:
             {{- range $key, $entry := .Values.initScripts -}}
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToJob }}
-            - name: galaxy-initscripts-{{ $key }}
+            - name: galaxy-initscripts-{{ $key | lower }}
               mountPath: {{ $.Values.initScripts.mountPath }}
               subPath: {{ $key }}.sh
             {{- end }}
@@ -121,13 +121,13 @@ spec:
           {{- range $key, $entry := .Values.initScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToJob }}
-        - name: galaxy-initscripts-{{ $key }}
+        - name: galaxy-initscripts-{{ $key | lower }}
           {{- if $entry.useSecret }}
           secret:
-            secretName: {{ include "galaxy.fullname" $ }}-{{ $key }}
+            secretName: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}
           {{- else }}
           configMap:
-            name: {{ include "galaxy.fullname" $ }}-{{ $key }}
+            name: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -66,7 +66,7 @@ spec:
 {{- end }}
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
-          command: ['
+          command: ['sh', '-c', '
           {{- range $key, $entry := .Values.initScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToJob -}}
@@ -74,8 +74,8 @@ spec:
           {{- end -}}
           {{- end -}}
           {{- end -}}
-          python', '/galaxy/server/scripts/galaxy-main']
-          args: ['-c', '/galaxy/server/config/galaxy.yml', '--server-name', '$(POD_NAME)', '--attach-to-pool', 'job-handlers']
+          python /galaxy/server/scripts/galaxy-main -c /galaxy/server/config/galaxy.yml --server-name $(POD_NAME) --attach-to-pool job-handlers']
+          args: []
           volumeMounts:
             {{- range $key, $entry := .Values.initScripts -}}
             {{- if (not (eq $key "mountPath")) -}}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -26,10 +26,10 @@ spec:
       initContainers:
         - name: {{ .Chart.Name }}-init-postgres
           image: alpine:3.7
-          command: ['sh', '-c', 'chown 101:101 {{.Values.persistence.mountPath}}; until nc -z -w3 {{ template "galaxy-postgresql.fullname" $ }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done;']
+          command: ['sh', '-c', 'chown 101:101 {{ .Values.persistence.mountPath }}; until nc -z -w3 {{ template "galaxy-postgresql.fullname" $ }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done;']
           volumeMounts:
             - name: galaxy-data
-              mountPath: {{.Values.persistence.mountPath}}
+              mountPath: {{ .Values.persistence.mountPath }}
         - name: {{ .Chart.Name }}-init-mounts
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: ['sh', '-c', {{ include "galaxy.init-container-commands" . | squote }}]
@@ -43,7 +43,7 @@ spec:
               mountPath: /galaxy/server/config/mutable/
               subPath: config
             - name: galaxy-data
-              mountPath: {{.Values.persistence.mountPath}}
+              mountPath: {{ .Values.persistence.mountPath }}
         {{- range $key, $entry := .Values.initContainers -}}
         {{- if $entry.applyToJob }}
         - name: {{ $.Chart.Name}}-{{ $key }}
@@ -81,9 +81,9 @@ spec:
             {{- range $key, $entry := .Values.initScripts -}}
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToJob }}
-            - name: galaxy-initscripts-{{$key}}
+            - name: galaxy-initscripts-{{ $key }}
               mountPath: {{ $.Values.initScripts.mountPath }}
-              subPath: {{$key}}.sh
+              subPath: {{ $key }}.sh
             {{- end }}
             {{- end }}
             {{- end }}
@@ -101,7 +101,7 @@ spec:
               mountPath: /galaxy/server/config/mutable/
               subPath: config
             - name: galaxy-data
-              mountPath: {{.Values.persistence.mountPath}}
+              mountPath: {{ .Values.persistence.mountPath }}
             {{- if .Values.cvmfs.enabled }}
             - name: cvmfs-gxy-main
               mountPath: {{ .Values.cvmfs.main.mountPath }}
@@ -122,13 +122,13 @@ spec:
           {{- range $key, $entry := .Values.initScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToJob }}
-        - name: galaxy-initscripts-{{$key}}
+        - name: galaxy-initscripts-{{ $key }}
           {{- if $entry.useSecret }}
           secret:
-            secretName: {{ include "galaxy.fullname" $ }}-{{$key}}
+            secretName: {{ include "galaxy.fullname" $ }}-{{ $key }}
           {{- else }}
           configMap:
-            name: {{ include "galaxy.fullname" $ }}-{{$key}}
+            name: {{ include "galaxy.fullname" $ }}-{{ $key }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/galaxy/templates/deployment-job.yaml
+++ b/galaxy/templates/deployment-job.yaml
@@ -81,7 +81,7 @@ spec:
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToJob }}
             - name: galaxy-initscripts-{{ $key | lower }}
-              mountPath: {{ $.Values.initScripts.mountPath }}
+              mountPath: {{ $.Values.initScripts.mountPath }}/{{ $key }}.sh
               subPath: {{ $key }}.sh
             {{- end }}
             {{- end }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -45,6 +45,34 @@ spec:
             - name: galaxy-data
               mountPath: /galaxy/server/config/mutable/
               subPath: config
+        - name: {{ $.Chart.Name }}-initscripts
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          command: ['sh', '-c', 'echo "Starting to run init scripts"
+          {{- range $key, $entry := .Values.initScripts -}}
+          {{- if $entry.applyToWeb -}}
+           && echo "Running {{$key}}.sh" && sh /galaxy/initscripts/{{$key}}.sh
+          {{- end -}}
+          {{- end -}}
+          ']
+          volumeMounts:
+            {{- range $key, $entry := .Values.initScripts -}}
+            {{- if $entry.applyToWeb }}
+            - name: galaxy-initscripts-{{$key}}
+              mountPath: /galaxy/initscripts
+              subPath: {{$key}}.sh
+            - name: galaxy-data
+              mountPath: {{ $.Values.persistence.mountPath }}
+            {{- end }}
+            {{- end }}
+        {{- range $key, $entry := .Values.initContainers -}}
+        {{- if $entry.applyToWeb }}
+        - name: {{ $.Chart.Name}}-{{ $key }}
+          image: {{ tpl $entry.image $ }}
+          command: {{ tpl $entry.command $ }}
+          volumeMounts:
+            {{- tpl ($entry.volumeMounts | toYaml) $ | nindent 12 }}
+        {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -112,6 +140,18 @@ spec:
           {{- else }}
           configMap:
             name: {{ template "galaxy.fullname" . }}-configs
+          {{- end }}
+          {{- range $key, $entry := .Values.initScripts -}}
+          {{- if $entry.applyToWeb }}
+        - name: galaxy-initscripts-{{$key}}
+          {{- if $entry.useSecret }}
+          secret:
+            secretName: {{ include "galaxy.fullname" $ }}-{{$key}}
+          {{- else }}
+          configMap:
+            name: {{ include "galaxy.fullname" $ }}-{{$key}}
+          {{- end }}
+          {{- end }}
           {{- end }}
         - name: galaxy-job-rules
           configMap:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -45,28 +45,9 @@ spec:
             - name: galaxy-data
               mountPath: /galaxy/server/config/mutable/
               subPath: config
-        - name: {{ $.Chart.Name }}-initscripts
-          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
-          command: ['sh', '-c', 'echo "Starting to run init scripts"
-          {{- range $key, $entry := .Values.initScripts -}}
-          {{- if $entry.applyToWeb -}}
-           && echo "Running {{$key}}.sh" && sh /galaxy/initscripts/{{$key}}.sh
-          {{- end -}}
-          {{- end -}}
-          ']
-          volumeMounts:
-            {{- range $key, $entry := .Values.initScripts -}}
-            {{- if $entry.applyToWeb }}
-            - name: galaxy-initscripts-{{$key}}
-              mountPath: /galaxy/initscripts
-              subPath: {{$key}}.sh
-            - name: galaxy-data
-              mountPath: {{ $.Values.persistence.mountPath }}
-            {{- end }}
-            {{- end }}
         {{- range $key, $entry := .Values.initContainers -}}
         {{- if $entry.applyToWeb }}
-        - name: {{ $.Chart.Name}}-{{ $key }}
+        - name: {{ $.Chart.Name }}-{{ $key }}
           image: {{ tpl $entry.image $ }}
           command: {{ tpl $entry.command $ }}
           volumeMounts:
@@ -87,8 +68,16 @@ spec:
 {{- end }}
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
-          command: ["/galaxy/server/.venv/bin/uwsgi"]
-          args: ["--yaml", "/galaxy/server/config/galaxy.yml"]
+          command: ['
+          {{- range $key, $entry := .Values.initScripts -}}
+          {{- if (not (eq $key "mountPath")) -}}
+          {{- if $entry.applyToWeb -}}
+          sh {{ $.Values.initScripts.mountPath }}/{{ $key }}{{ ".sh && " }}
+          {{- end -}}
+          {{- end -}}
+          {{- end -}}
+          /galaxy/server/.venv/bin/uwsgi']
+          args: ['--yaml', '/galaxy/server/config/galaxy.yml']
           readinessProbe:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}
@@ -103,6 +92,15 @@ spec:
             periodSeconds: 60
             failureThreshold: 10
           volumeMounts:
+            {{- range $key, $entry := .Values.initScripts -}}
+            {{- if (not (eq $key "mountPath")) -}}
+            {{- if $entry.applyToWeb }}
+            - name: galaxy-initscripts-{{$key}}
+              mountPath: {{ $.Values.initScripts.mountPath }}
+              subPath: {{$key}}.sh
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- range $key,$entry := .Values.configs }}
             - name: galaxy-conf-files
               mountPath: /galaxy/server/config/{{ $key }}
@@ -142,6 +140,7 @@ spec:
             name: {{ template "galaxy.fullname" . }}-configs
           {{- end }}
           {{- range $key, $entry := .Values.initScripts -}}
+          {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToWeb }}
         - name: galaxy-initscripts-{{$key}}
           {{- if $entry.useSecret }}
@@ -150,6 +149,7 @@ spec:
           {{- else }}
           configMap:
             name: {{ include "galaxy.fullname" $ }}-{{$key}}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -68,10 +68,10 @@ spec:
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
           command: ['sh', '-c', '
-          {{- range $key, $entry := .Values.initScripts -}}
+          {{- range $key, $entry := .Values.extraInitScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToWeb -}}
-          sh {{ $.Values.initScripts.mountPath }}/{{ $key }}{{ ".sh && " }}
+          sh {{ $.Values.extraInitScripts.mountPath }}/{{ $key }}{{ ".sh && " }}
           {{- end -}}
           {{- end -}}
           {{- end -}}
@@ -91,11 +91,11 @@ spec:
             periodSeconds: 60
             failureThreshold: 10
           volumeMounts:
-            {{- range $key, $entry := .Values.initScripts -}}
+            {{- range $key, $entry := .Values.extraInitScripts -}}
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToWeb }}
-            - name: galaxy-initscripts-{{ $key | lower }}
-              mountPath: {{ $.Values.initScripts.mountPath }}/{{ $key }}.sh
+            - name: galaxy-extraInitScripts-{{ $key | lower }}
+              mountPath: {{ $.Values.extraInitScripts.mountPath }}/{{ $key }}.sh
               subPath: {{ $key }}.sh
             {{- end }}
             {{- end }}
@@ -138,10 +138,10 @@ spec:
           configMap:
             name: {{ template "galaxy.fullname" . }}-configs
           {{- end }}
-          {{- range $key, $entry := .Values.initScripts -}}
+          {{- range $key, $entry := .Values.extraInitScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToWeb }}
-        - name: galaxy-initscripts-{{ $key | lower }}
+        - name: galaxy-extraInitScripts-{{ $key | lower }}
           {{- if $entry.useSecret }}
           secret:
             secretName: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -45,13 +45,12 @@ spec:
             - name: galaxy-data
               mountPath: /galaxy/server/config/mutable/
               subPath: config
-        {{- range $key, $entry := .Values.initContainers -}}
-        {{- if $entry.applyToWeb }}
-        - name: {{ $.Chart.Name }}-{{ $key }}
-          image: {{ tpl $entry.image $ }}
-          command: {{ tpl $entry.command $ }}
-          volumeMounts:
-            {{- tpl ($entry.volumeMounts | toYaml) $ | nindent 12 }}
+        {{- if .Values.extraInitContainers -}}
+        {{- range $each := .Values.extraInitContainers -}}
+        {{- if $each.applyToWeb -}}
+        {{- print "- " | nindent 8 -}}
+        {{- tpl ((unset (unset $each "applyToJob") "applyToWeb") | toYaml | indent 10 | trim) $ -}}
+        {{- end }}
         {{- end }}
         {{- end }}
       containers:

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -95,7 +95,7 @@ spec:
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToWeb }}
             - name: galaxy-initscripts-{{ $key | lower }}
-              mountPath: {{ $.Values.initScripts.mountPath }}
+              mountPath: {{ $.Values.initScripts.mountPath }}/{{ $key }}.sh
               subPath: {{ $key }}.sh
             {{- end }}
             {{- end }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -94,7 +94,7 @@ spec:
             {{- range $key, $entry := .Values.initScripts -}}
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToWeb }}
-            - name: galaxy-initscripts-{{ $key }}
+            - name: galaxy-initscripts-{{ $key | lower }}
               mountPath: {{ $.Values.initScripts.mountPath }}
               subPath: {{ $key }}.sh
             {{- end }}
@@ -141,13 +141,13 @@ spec:
           {{- range $key, $entry := .Values.initScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToWeb }}
-        - name: galaxy-initscripts-{{ $key }}
+        - name: galaxy-initscripts-{{ $key | lower }}
           {{- if $entry.useSecret }}
           secret:
-            secretName: {{ include "galaxy.fullname" $ }}-{{ $key }}
+            secretName: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}
           {{- else }}
           configMap:
-            name: {{ include "galaxy.fullname" $ }}-{{ $key }}
+            name: {{ include "galaxy.fullname" $ }}-{{ $key | lower }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -27,10 +27,10 @@ spec:
       initContainers:
         - name: {{ .Chart.Name }}-init-postgres
           image: alpine:3.7
-          command: ['sh', '-c', 'chown 101:101 {{.Values.persistence.mountPath}}; until nc -z -w3 {{ template "galaxy-postgresql.fullname" $ }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done;']
+          command: ['sh', '-c', 'chown 101:101 {{ .Values.persistence.mountPath }}; until nc -z -w3 {{ template "galaxy-postgresql.fullname" $ }} 5432; do echo waiting for galaxy-postgres service; sleep 1; done;']
           volumeMounts:
             - name: galaxy-data
-              mountPath: {{.Values.persistence.mountPath}}
+              mountPath: {{ .Values.persistence.mountPath }}
         - name: {{ .Chart.Name }}-init-mounts
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: ['sh', '-c', {{ include "galaxy.init-container-commands" . | squote }}]
@@ -41,7 +41,7 @@ spec:
               subPath: {{ $key }}
             {{- end }}
             - name: galaxy-data
-              mountPath: {{.Values.persistence.mountPath}}
+              mountPath: {{ .Values.persistence.mountPath }}
             - name: galaxy-data
               mountPath: /galaxy/server/config/mutable/
               subPath: config
@@ -95,9 +95,9 @@ spec:
             {{- range $key, $entry := .Values.initScripts -}}
             {{- if (not (eq $key "mountPath")) -}}
             {{- if $entry.applyToWeb }}
-            - name: galaxy-initscripts-{{$key}}
+            - name: galaxy-initscripts-{{ $key }}
               mountPath: {{ $.Values.initScripts.mountPath }}
-              subPath: {{$key}}.sh
+              subPath: {{ $key }}.sh
             {{- end }}
             {{- end }}
             {{- end }}
@@ -112,7 +112,7 @@ spec:
               subPath: {{ $key }}
             {{- end }}
             - name: galaxy-data
-              mountPath: {{.Values.persistence.mountPath}}
+              mountPath: {{ .Values.persistence.mountPath }}
             - name: galaxy-data
               mountPath: /galaxy/server/config/mutable/
               subPath: config
@@ -142,13 +142,13 @@ spec:
           {{- range $key, $entry := .Values.initScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToWeb }}
-        - name: galaxy-initscripts-{{$key}}
+        - name: galaxy-initscripts-{{ $key }}
           {{- if $entry.useSecret }}
           secret:
-            secretName: {{ include "galaxy.fullname" $ }}-{{$key}}
+            secretName: {{ include "galaxy.fullname" $ }}-{{ $key }}
           {{- else }}
           configMap:
-            name: {{ include "galaxy.fullname" $ }}-{{$key}}
+            name: {{ include "galaxy.fullname" $ }}-{{ $key }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/galaxy/templates/deployment-web.yaml
+++ b/galaxy/templates/deployment-web.yaml
@@ -67,7 +67,7 @@ spec:
 {{- end }}
             - name: GALAXY_CONFIG_DATABASE_CONNECTION
               value: postgresql://{{ .Values.postgresql.galaxyDatabaseUser }}:$(GALAXY_DB_USER_PASSWORD)@{{ template "galaxy-postgresql.fullname" . }}/galaxy
-          command: ['
+          command: ['sh', '-c', '
           {{- range $key, $entry := .Values.initScripts -}}
           {{- if (not (eq $key "mountPath")) -}}
           {{- if $entry.applyToWeb -}}
@@ -75,8 +75,8 @@ spec:
           {{- end -}}
           {{- end -}}
           {{- end -}}
-          /galaxy/server/.venv/bin/uwsgi']
-          args: ['--yaml', '/galaxy/server/config/galaxy.yml']
+          /galaxy/server/.venv/bin/uwsgi --yaml /galaxy/server/config/galaxy.yml']
+          args: []
           readinessProbe:
             httpGet:
               path: {{ template "galaxy.add_trailing_slash" .Values.ingress.path }}

--- a/galaxy/templates/init-scripts.yaml
+++ b/galaxy/templates/init-scripts.yaml
@@ -1,0 +1,24 @@
+{{- $dot := . -}}
+{{- range $key, $entry := .Values.initScripts -}}
+{{- if $entry }}
+apiVersion: v1
+metadata:
+  name: {{ include "galaxy.fullname" $dot }}-{{$key}}
+  labels:
+    app.kubernetes.io/name: {{ include "galaxy.name" $dot }}
+    helm.sh/chart: {{ include "galaxy.chart" $dot }}
+    app.kubernetes.io/instance: {{ $dot.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $dot.Release.Service }}
+{{- if $entry.useSecret }}
+kind: Secret
+type: Opaque
+stringData: |
+{{- else }}
+kind: ConfigMap
+data: |
+{{- end }}
+  {{- tpl (tpl $entry.content $) $ | nindent 2 }}
+---
+{{- end }}
+{{- end }}
+

--- a/galaxy/templates/init-scripts.yaml
+++ b/galaxy/templates/init-scripts.yaml
@@ -17,7 +17,8 @@ stringData: |
 kind: ConfigMap
 data: |
 {{- end }}
-  {{- tpl (tpl $entry.content $) $ | nindent 2 }}
+  {{- $key | nindent 2 }}.sh: |
+    {{- tpl (tpl $entry.content $) $ | nindent 4 }}
 ---
 {{- end }}
 {{- end }}

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -33,6 +33,40 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
+initContainers:
+  myFirstContainer:
+    applyToJob: true
+    applyToWeb: true
+    image: myrepo/myimage:mytag
+    command: "['sh', '-c', 'cp my-path/to/my/file {{.Values.persistence.mountPath}}/custom-files']"
+    volumeMounts:
+      - name: galaxy-data
+        mountPath: "{{.Values.persistence.mountPath}}"
+  mySecondContainer:
+    applyToJob: true
+    applyToWeb: false
+    image: myrepo/myimage:mytag
+    command: "['sh', '-c', 'cp something {{.Values.persistence.mountPath}}/custom-files ']"
+    volumeMounts:
+      - name: galaxy-data
+        mountPath: "{{.Values.persistence.mountPath}}"
+
+initScripts:
+  myFirstScript:
+    useSecret: false
+    applyToJob: false
+    applyToWeb: true
+    content: |
+      #!/bin/sh
+      echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
+  mySecondScript:
+    useSecret: true
+    applyToWeb: true
+    applyToJob: true
+    content: |
+      #!/bin/sh
+      chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
+
 extraEnv:
 # If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's
 # secretKeyRef must also be set to match. Leave defaults to create a new secret.

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -34,19 +34,19 @@ persistence:
   mountPath: /galaxy/server/database
 
 # extraInitContainers:
-#   - name: myFirstContainer
+#   - name: my-first-container
 #     applyToJob: true
 #     applyToWeb: true
-#     image: myrepo/myimage:mytag
-#     command: ['sh', '-c', 'cp my-path/to/my/file {{.Values.persistence.mountPath}}/custom-files']
+#     image: "{{.Values.image.repository}}:{{.Values.image.tag}}"
+#     command: ['sh', '-c', 'cp "/galaxy/server/config/job_conf.xml.sample_advanced" {{.Values.persistence.mountPath}}/']
 #     volumeMounts:
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
-#   - name: mySecondContainer
+#   - name: my-second-container
 #     applyToJob: true
 #     applyToWeb: false
-#     image: myrepo/myimage:mytag
-#     command: ['sh', '-c', 'cp something {{.Values.persistence.mountPath}}/custom-files ']
+#     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+#     command: ['sh', '-c', 'cp "/galaxy/server/config/galaxy.yml" {{.Values.persistence.mountPath}}/']
 #     volumeMounts:
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
@@ -59,14 +59,14 @@ persistence:
 #     applyToWeb: true
 #     content: |
 #       #!/bin/sh
-#       echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
+#       echo "Hello web world" > {{.Values.persistence.mountPath}}/hello-web.txt
 #   mySecondScript:
 #     useSecret: true
 #     applyToWeb: true
 #     applyToJob: true
 #     content: |
 #       #!/bin/sh
-#       chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
+#       echo "Hello both job and web worlds" > {{.Values.persistence.mountPath}}/hello-both.txt
 
 extraEnv:
 # If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -52,6 +52,7 @@ persistence:
 #         mountPath: "{{.Values.persistence.mountPath}}"
 # 
 initScripts:
+  mountPath: /galaxy/server/scripts/initscripts
   myFirstScript:
     useSecret: false
     applyToJob: false

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -33,39 +33,39 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
-initContainers:
-  myFirstContainer:
-    applyToJob: true
-    applyToWeb: true
-    image: myrepo/myimage:mytag
-    command: "['sh', '-c', 'cp my-path/to/my/file {{.Values.persistence.mountPath}}/custom-files']"
-    volumeMounts:
-      - name: galaxy-data
-        mountPath: "{{.Values.persistence.mountPath}}"
-  mySecondContainer:
-    applyToJob: true
-    applyToWeb: false
-    image: myrepo/myimage:mytag
-    command: "['sh', '-c', 'cp something {{.Values.persistence.mountPath}}/custom-files ']"
-    volumeMounts:
-      - name: galaxy-data
-        mountPath: "{{.Values.persistence.mountPath}}"
-
-initScripts:
-  myFirstScript:
-    useSecret: false
-    applyToJob: false
-    applyToWeb: true
-    content: |
-      #!/bin/sh
-      echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
-  mySecondScript:
-    useSecret: true
-    applyToWeb: true
-    applyToJob: true
-    content: |
-      #!/bin/sh
-      chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
+# initContainers:
+#   myFirstContainer:
+#     applyToJob: true
+#     applyToWeb: true
+#     image: myrepo/myimage:mytag
+#     command: "['sh', '-c', 'cp my-path/to/my/file {{.Values.persistence.mountPath}}/custom-files']"
+#     volumeMounts:
+#       - name: galaxy-data
+#         mountPath: "{{.Values.persistence.mountPath}}"
+#   mySecondContainer:
+#     applyToJob: true
+#     applyToWeb: false
+#     image: myrepo/myimage:mytag
+#     command: "['sh', '-c', 'cp something {{.Values.persistence.mountPath}}/custom-files ']"
+#     volumeMounts:
+#       - name: galaxy-data
+#         mountPath: "{{.Values.persistence.mountPath}}"
+# 
+# initScripts:
+#   myFirstScript:
+#     useSecret: false
+#     applyToJob: false
+#     applyToWeb: true
+#     content: |
+#       #!/bin/sh
+#       echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
+#   mySecondScript:
+#     useSecret: true
+#     applyToWeb: true
+#     applyToJob: true
+#     content: |
+#       #!/bin/sh
+#       chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
 
 extraEnv:
 # If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -51,21 +51,21 @@ persistence:
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
 # 
-# initScripts:
-#   myFirstScript:
-#     useSecret: false
-#     applyToJob: false
-#     applyToWeb: true
-#     content: |
-#       #!/bin/sh
-#       echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
-#   mySecondScript:
-#     useSecret: true
-#     applyToWeb: true
-#     applyToJob: true
-#     content: |
-#       #!/bin/sh
-#       chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
+initScripts:
+  myFirstScript:
+    useSecret: false
+    applyToJob: false
+    applyToWeb: true
+    content: |
+      #!/bin/sh
+      echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
+  mySecondScript:
+    useSecret: true
+    applyToWeb: true
+    applyToJob: true
+    content: |
+      #!/bin/sh
+      chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
 
 extraEnv:
 # If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -51,8 +51,8 @@ persistence:
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
 
-# initScripts:
-#   mountPath: /galaxy/server/scripts/initscripts
+# extraInitScripts:
+#   mountPath: /galaxy/server/scripts/extraInitScripts
 #   myFirstScript:
 #     useSecret: false
 #     applyToJob: false

--- a/galaxy/values-cvmfs.yaml
+++ b/galaxy/values-cvmfs.yaml
@@ -33,40 +33,40 @@ persistence:
   size: 10Gi
   mountPath: /galaxy/server/database
 
-# initContainers:
-#   myFirstContainer:
+# extraInitContainers:
+#   - name: myFirstContainer
 #     applyToJob: true
 #     applyToWeb: true
 #     image: myrepo/myimage:mytag
-#     command: "['sh', '-c', 'cp my-path/to/my/file {{.Values.persistence.mountPath}}/custom-files']"
+#     command: ['sh', '-c', 'cp my-path/to/my/file {{.Values.persistence.mountPath}}/custom-files']
 #     volumeMounts:
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
-#   mySecondContainer:
+#   - name: mySecondContainer
 #     applyToJob: true
 #     applyToWeb: false
 #     image: myrepo/myimage:mytag
-#     command: "['sh', '-c', 'cp something {{.Values.persistence.mountPath}}/custom-files ']"
+#     command: ['sh', '-c', 'cp something {{.Values.persistence.mountPath}}/custom-files ']
 #     volumeMounts:
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
-# 
-initScripts:
-  mountPath: /galaxy/server/scripts/initscripts
-  myFirstScript:
-    useSecret: false
-    applyToJob: false
-    applyToWeb: true
-    content: |
-      #!/bin/sh
-      echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
-  mySecondScript:
-    useSecret: true
-    applyToWeb: true
-    applyToJob: true
-    content: |
-      #!/bin/sh
-      chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
+
+# initScripts:
+#   mountPath: /galaxy/server/scripts/initscripts
+#   myFirstScript:
+#     useSecret: false
+#     applyToJob: false
+#     applyToWeb: true
+#     content: |
+#       #!/bin/sh
+#       echo "Hello world" > {{.Values.persistence.mountPath}}/hello-world.txt
+#   mySecondScript:
+#     useSecret: true
+#     applyToWeb: true
+#     applyToJob: true
+#     content: |
+#       #!/bin/sh
+#       chmod 400 {{.Values.persistence.mountPath}}/hello-world.txt
 
 extraEnv:
 # If using an existing secret, the postgresql.extraEnv.GALAXY_DB_USER_PASSWORD's

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -75,6 +75,41 @@ tolerations: []
 
 affinity: {}
 
+# extraInitContainers:
+#   - name: my-first-container
+#     applyToJob: true
+#     applyToWeb: true
+#     image: "{{.Values.image.repository}}:{{.Values.image.tag}}"
+#     command: ['sh', '-c', 'cp "/galaxy/server/config/job_conf.xml.sample_advanced" {{.Values.persistence.mountPath}}/']
+#     volumeMounts:
+#       - name: galaxy-data
+#         mountPath: "{{.Values.persistence.mountPath}}"
+#   - name: my-second-container
+#     applyToJob: true
+#     applyToWeb: false
+#     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+#     command: ['sh', '-c', 'cp "/galaxy/server/config/galaxy.yml" {{.Values.persistence.mountPath}}/']
+#     volumeMounts:
+#       - name: galaxy-data
+#         mountPath: "{{.Values.persistence.mountPath}}"
+
+# initScripts:
+#   mountPath: /galaxy/server/scripts/initscripts
+#   myFirstScript:
+#     useSecret: false
+#     applyToJob: false
+#     applyToWeb: true
+#     content: |
+#       #!/bin/sh
+#       echo "Hello web world" > {{.Values.persistence.mountPath}}/hello-web.txt
+#   mySecondScript:
+#     useSecret: true
+#     applyToWeb: true
+#     applyToJob: true
+#     content: |
+#       #!/bin/sh
+#       echo "Hello both job and web worlds" > {{.Values.persistence.mountPath}}/hello-both.txt
+
 postgresql:
   enabled: true
   galaxyDatabaseUser: galaxydbuser

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -93,8 +93,8 @@ affinity: {}
 #       - name: galaxy-data
 #         mountPath: "{{.Values.persistence.mountPath}}"
 
-# initScripts:
-#   mountPath: /galaxy/server/scripts/initscripts
+# extraInitScripts:
+#   mountPath: /galaxy/server/scripts/extraInitScripts
 #   myFirstScript:
 #     useSecret: false
 #     applyToJob: false


### PR DESCRIPTION
Re: https://github.com/CloudVE/galaxy-kubernetes/issues/30

Adds the possibility to specify full init containers, or simply inject `sh` scripts that will be run through a pre-made init container that uses the same image as the main galaxy containers, and mounts the persistent volume
I included a commented out example in `values-cvmfs`. One thing to note is that the initscripts container will run (echoing one line) even if no scripts are specified rn. I can however change it to either use the same init container that we're using, just thought it should be isolated ideally.